### PR TITLE
[수정] 플레이어 재생목록 아래 하단 바 가로폭 낮은 폰 픽셀 오버플로우 이슈 수정

### DIFF
--- a/lib/widgets/player/player_bottom.dart
+++ b/lib/widgets/player/player_bottom.dart
@@ -152,7 +152,7 @@ class PlayerPlaylistBottom extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               Padding(
-                padding: const EdgeInsets.fromLTRB(0, 7, 0, 8),
+                padding: const EdgeInsets.fromLTRB(0, 7, 7, 8),
                 child: AspectRatio(
                   aspectRatio: 16 / 9,
                   child: loadImage(
@@ -197,11 +197,11 @@ class PlayerPlaylistBottom extends StatelessWidget {
                         audioProvider.toNext();
                       }),
                       audioProvider.shuffle
-                          ? iconBtn("ic_32_random_on", edgePadding: true,
+                          ? iconBtn("ic_32_random_on", edgePadding: false,
                               onTap: () {
                               audioProvider.toggleShuffle();
                             })
-                          : iconBtn("ic_32_random_off", edgePadding: true,
+                          : iconBtn("ic_32_random_off", edgePadding: false,
                               onTap: () {
                               audioProvider.toggleShuffle();
                             }),


### PR DESCRIPTION
감자님이 수정하신 부분 적용해도 제 폰에서 픽셀 이슈 나서 추가 수정했습니당